### PR TITLE
(ui-fabric-react) Changed typescript version, added configs to tsconfig.json

### DIFF
--- a/ui-fabric-react/package.json
+++ b/ui-fabric-react/package.json
@@ -23,7 +23,7 @@
     "gulp-typescript": "^3.1.3",
     "gulp-webpack": "^1.5.0",
     "tfx-cli": "^0.3.45",
-    "typescript": "^2.0.10",
+    "typescript": "2.3.4",
     "webpack": "^1.13.3",
     "yargs": "^6.5.0"
   },

--- a/ui-fabric-react/tsconfig.json
+++ b/ui-fabric-react/tsconfig.json
@@ -6,6 +6,7 @@
         "noImplicitAny": false,
         "jsx": "react",
         "sourceMap": false,
+        "baseUrl": ".",
         "paths": {
             "OfficeFabric/*": ["node_modules/office-ui-fabric-react/lib-amd/*"]
         },

--- a/ui-fabric-react/tsconfig.json
+++ b/ui-fabric-react/tsconfig.json
@@ -8,6 +8,7 @@
         "sourceMap": false,
         "paths": {
             "OfficeFabric/*": ["node_modules/office-ui-fabric-react/lib-amd/*"]
-        }
+        },
+        "skipLibCheck": true
     }
 }


### PR DESCRIPTION
There's still a compile error on WorkItemSearch.ts
scripts\WorkItemSearch.ts(41,13): error TS2322: Type 'WorkItemTrackingHttpClient3_1' is not assignable to type 'WorkItemTrackingHttpClient'.
  Property 'getWorkArtifactLinkTypes' is missing in type 'WorkItemTrackingHttpClient3_1'.