### PR TITLE
Replace 404-URL with working URL in ReadeMe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Visual Studio Team Services (VSTS) Sample Extensions
  
-Samples to help jump-start your development of [extensions for Visual Studio Team Services (VSTS)](http://www.visualstudio.com/integrate/extensions/overview).
+Samples to help jump-start your development of [extensions for Visual Studio Team Services (VSTS)](http://www.visualstudio.com/team-services/extend).
 
 ## Get started
 


### PR DESCRIPTION
Change hyperlink for VSTS link from the 404-inducing "https://www.visualstudio.com/integrate/extensions/overview" to "http://www.visualstudio.com/team-services/extend".

I've taken a guess that "http://www.visualstudio.com/team-services/extend" is the correct target URL, but obviously I could be wrong here so please double check this.