### PR TITLE
Addition of <publisher>.<extension-id> to configuration ID sample

### DIFF
--- a/widgets/vss-extension.json
+++ b/widgets/vss-extension.json
@@ -240,7 +240,7 @@
             "type": "ms.vss-dashboards-web.widget",
             "targets": [
                 "ms.vss-dashboards-web.widget-catalog",
-                ".HelloWorldWidget.Configuration"
+                "fabrikam.vsts-extensions-myExtensions.HelloWorldWidget.Configurationn"
             ],
             "properties": {
                 "name": "Hello World Widget 3 (with config)",


### PR DESCRIPTION
According to the [Hello World with Configuration](https://docs.microsoft.com/en-us/azure/devops/extend/develop/add-dashboard-widget?view=vsts#step-5-extension-manifest-updates-1) sample extension widget, the array of targets for the widget needs to contain the ID for the configuration in the form <publisher>.<extension-id>.<configuration-id>, which in the case of the sample would be `fabrikam.vsts-extensions-myExtensions.HelloWorldWidget.Configuration`

However the sample source code [here](https://github.com/Microsoft/vsts-extension-samples/blob/master/widgets/vss-extension.json) appears not to following this ID naming convention.

The vss-extension.json file currently contains 

`
            "targets": [
                "ms.vss-dashboards-web.widget-catalog",
                ".HelloWorldWidget.Configuration"
            ],
`

but I suspect it should contain the following

`
            "targets": [
                "ms.vss-dashboards-web.widget-catalog",
                "fabrikam.vsts-extensions-myExtensions.HelloWorldWidget.Configuration"
            ],
`