### PR TITLE
Fix issue: The registered object ms-samples

### DIFF
--- a/contributions-guide/vss-extension.json
+++ b/contributions-guide/vss-extension.json
@@ -76,7 +76,8 @@
                 "title": "ms.vss-code-web.source-item-menu",
                 "icon": "images/show-properties.png",
                 "group": "actions",
-                "uri": "main.html"
+                "uri": "main.html",
+                "registeredObjectId": "showProperties"
             }
         },
         {


### PR DESCRIPTION
Fixing this issue in the example: 

'''
Failed to load menu items for ms-samples.samples-contributions-guide.showProperties: "The registered object ms-samples.samples-contributions-guide.showProperties could not be found."
'''